### PR TITLE
:bookmark: bump version 0.1.0 -> 0.1.1

### DIFF
--- a/.copier/package.yml
+++ b/.copier/package.yml
@@ -3,7 +3,7 @@ _commit: v2024.27-4-g3fe659b
 _src_path: /home/josh/projects/work/django-twc-package
 author_email: josh@joshthomas.dev
 author_name: Josh Thomas
-current_version: 0.1.0
+current_version: 0.1.1
 django_versions:
   - "4.2"
   - "5.0"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ and this project attempts to adhere to [Semantic Versioning](https://semver.org/
 
 ## [Unreleased]
 
+## [0.1.1]
+
 ### Fixed
 
 - Fixed rendering of flat attributes in `{% bird %}` component templates. Previously, a small mistake in trying to render `boolean` values caused no attributes to be rendered. E.g. `{% bird foo disabled=True %}` should have been rendered using `{{ attrs }}` inside the `foo` bird component as just `disabled` -- instead nothing was being rendered, even `key="value"` attributes.
@@ -39,5 +41,6 @@ and this project attempts to adhere to [Semantic Versioning](https://semver.org/
 
 - Josh Thomas <josh@joshthomas.dev> (maintainer)
 
-[unreleased]: https://github.com/joshuadavidthomas/django-bird/compare/v0.1.0...HEAD
+[unreleased]: https://github.com/joshuadavidthomas/django-bird/compare/v0.1.1...HEAD
 [0.1.0]: https://github.com/joshuadavidthomas/django-bird/releases/tag/v0.1.0
+[0.1.1]: https://github.com/joshuadavidthomas/django-bird/releases/tag/v0.1.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,7 +74,7 @@ Source = "https://github.com/joshuadavidthomas/django-bird"
 [tool.bumpver]
 commit = true
 commit_message = ":bookmark: bump version {old_version} -> {new_version}"
-current_version = "0.1.0"
+current_version = "0.1.1"
 push = false  # set to false for CI
 tag = false
 version_pattern = "MAJOR.MINOR.PATCH[PYTAGNUM]"

--- a/src/django_bird/__init__.py
+++ b/src/django_bird/__init__.py
@@ -1,3 +1,3 @@
 from __future__ import annotations
 
-__version__ = "0.1.0"
+__version__ = "0.1.1"

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -4,4 +4,4 @@ from django_bird import __version__
 
 
 def test_version():
-    assert __version__ == "0.1.0"
+    assert __version__ == "0.1.1"

--- a/uv.lock
+++ b/uv.lock
@@ -327,7 +327,7 @@ wheels = [
 
 [[package]]
 name = "django-bird"
-version = "0.1.0"
+version = "0.1.1"
 source = { editable = "." }
 dependencies = [
     { name = "django" },


### PR DESCRIPTION
- `1e27e57`: clean-up the rest of references to old package name (#28)
- `0d794dc`: refactor nox test runner to use uv (#32)
- `b2641f9`: swap company teams for personal account in CODEOWNERS
- `4998781`: set python version in nox sessions when syncing uv (#33)
- `fb4f6ce`: move pre-commit linting to nox session (#34)
- `7f14a28`: fix attribute rendering (#36)
- `7d8a145`: freshen up repo (#37)
- `c738595`: make bump executable