### PR TITLE
:bookmark: bump version 0.2.0 -> 0.3.0

### DIFF
--- a/.copier/package.yml
+++ b/.copier/package.yml
@@ -3,7 +3,7 @@ _commit: v2024.27-4-g3fe659b
 _src_path: /home/josh/projects/work/django-twc-package
 author_email: josh@joshthomas.dev
 author_name: Josh Thomas
-current_version: 0.2.0
+current_version: 0.3.0
 django_versions:
   - "4.2"
   - "5.0"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ and this project attempts to adhere to [Semantic Versioning](https://semver.org/
 
 ## [Unreleased]
 
+## [0.3.0]
+
 ### Added
 
 - Created `{% bird:prop %}` tag for defining properties within components. These operate similarly to the `{{ attrs }}` template context variable, but allow for setting defaults. Any attributes passed to a component will override the prop's default value, and props defined in a component template are automatically removed from the component's `attrs`. Props are accessible in templates via the `props` context variable (e.g. `{{ props.id }}`)
@@ -69,7 +71,8 @@ and this project attempts to adhere to [Semantic Versioning](https://semver.org/
 
 - Josh Thomas <josh@joshthomas.dev> (maintainer)
 
-[unreleased]: https://github.com/joshuadavidthomas/django-bird/compare/v0.2.0...HEAD
+[unreleased]: https://github.com/joshuadavidthomas/django-bird/compare/v0.3.0...HEAD
 [0.1.0]: https://github.com/joshuadavidthomas/django-bird/releases/tag/v0.1.0
 [0.1.1]: https://github.com/joshuadavidthomas/django-bird/releases/tag/v0.1.1
 [0.2.0]: https://github.com/joshuadavidthomas/django-bird/releases/tag/v0.2.0
+[0.3.0]: https://github.com/joshuadavidthomas/django-bird/releases/tag/v0.3.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,7 +74,7 @@ Source = "https://github.com/joshuadavidthomas/django-bird"
 [tool.bumpver]
 commit = true
 commit_message = ":bookmark: bump version {old_version} -> {new_version}"
-current_version = "0.2.0"
+current_version = "0.3.0"
 push = false  # set to false for CI
 tag = false
 version_pattern = "MAJOR.MINOR.PATCH[PYTAGNUM]"

--- a/src/django_bird/__init__.py
+++ b/src/django_bird/__init__.py
@@ -1,3 +1,3 @@
 from __future__ import annotations
 
-__version__ = "0.2.0"
+__version__ = "0.3.0"

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -4,4 +4,4 @@ from django_bird import __version__
 
 
 def test_version():
-    assert __version__ == "0.2.0"
+    assert __version__ == "0.3.0"

--- a/uv.lock
+++ b/uv.lock
@@ -327,7 +327,7 @@ wheels = [
 
 [[package]]
 name = "django-bird"
-version = "0.2.0"
+version = "0.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "django" },


### PR DESCRIPTION
- `7d3481c`: [pre-commit.ci] pre-commit autoupdate (#45)
- `e04cf55`: Bump astral-sh/setup-uv from 3 to 4 in the gha group (#44)
- `cf84c9f`: add initial registry for staticfiles (#46)
- `d35d517`: reorganize tags to dedicated directory (#48)
- `af12acf`: refactor tags a bit (#49)
- `c3395cd`: create `components` dir and move attrs and templates (#50)
- `df1a175`: create slots helper module (#51)
- `a66059c`: [pre-commit.ci] pre-commit autoupdate (#52)
- `73e1d35`: rename internal `BirdNode` attrs to params (#53)
- `a6370b2`: fix argument parsing in nox sessions
- `1ddaea9`: add `{% bird:prop %}` templatetag (#54)