### PR TITLE
:bookmark: bump version 0.4.0 -> 0.5.0

### DIFF
--- a/.copier/package.yml
+++ b/.copier/package.yml
@@ -3,7 +3,7 @@ _commit: v2024.27-4-g3fe659b
 _src_path: /home/josh/projects/work/django-twc-package
 author_email: josh@joshthomas.dev
 author_name: Josh Thomas
-current_version: 0.4.0
+current_version: 0.5.0
 django_versions:
   - "4.2"
   - "5.0"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ and this project attempts to adhere to [Semantic Versioning](https://semver.org/
 
 ## [Unreleased]
 
+## [0.5.0]
+
 ### Added
 
 - Added component caching with LRU (Least Recently Used) strategy via global `components` registry.
@@ -87,9 +89,10 @@ and this project attempts to adhere to [Semantic Versioning](https://semver.org/
 
 - Josh Thomas <josh@joshthomas.dev> (maintainer)
 
-[unreleased]: https://github.com/joshuadavidthomas/django-bird/compare/v0.4.0...HEAD
+[unreleased]: https://github.com/joshuadavidthomas/django-bird/compare/v0.5.0...HEAD
 [0.1.0]: https://github.com/joshuadavidthomas/django-bird/releases/tag/v0.1.0
 [0.1.1]: https://github.com/joshuadavidthomas/django-bird/releases/tag/v0.1.1
 [0.2.0]: https://github.com/joshuadavidthomas/django-bird/releases/tag/v0.2.0
 [0.3.0]: https://github.com/joshuadavidthomas/django-bird/releases/tag/v0.3.0
 [0.4.0]: https://github.com/joshuadavidthomas/django-bird/releases/tag/v0.4.0
+[0.5.0]: https://github.com/joshuadavidthomas/django-bird/releases/tag/v0.5.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,7 +76,7 @@ Source = "https://github.com/joshuadavidthomas/django-bird"
 [tool.bumpver]
 commit = true
 commit_message = ":bookmark: bump version {old_version} -> {new_version}"
-current_version = "0.4.0"
+current_version = "0.5.0"
 push = false  # set to false for CI
 tag = false
 version_pattern = "MAJOR.MINOR.PATCH[PYTAGNUM]"

--- a/src/django_bird/__init__.py
+++ b/src/django_bird/__init__.py
@@ -1,3 +1,3 @@
 from __future__ import annotations
 
-__version__ = "0.4.0"
+__version__ = "0.5.0"

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -4,4 +4,4 @@ from django_bird import __version__
 
 
 def test_version():
-    assert __version__ == "0.4.0"
+    assert __version__ == "0.5.0"

--- a/uv.lock
+++ b/uv.lock
@@ -332,7 +332,7 @@ wheels = [
 
 [[package]]
 name = "django-bird"
-version = "0.4.0"
+version = "0.5.0"
 source = { editable = "." }
 dependencies = [
     { name = "cachetools" },


### PR DESCRIPTION
- `5fd6016`: flatten library layout by moving `components/` module to base (#60)
- `f5badbd`: bump uv.lock (#61)
- `7f50704`: create `Components` dataclass (#62)
- `b6a5405`: add component registry for caching lookups (#63)