### PR TITLE
don't cache component retrieval when `DEBUG` is true

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ and this project attempts to adhere to [Semantic Versioning](https://semver.org/
 
 ## [Unreleased]
 
+### Changed
+
+- When `DEBUG=True`, the `django_bird.components.Registry` will no longer cache the retrieval of `Component` instances.
+
 ## [0.6.1]
 
 ### Fixed

--- a/src/django_bird/components.py
+++ b/src/django_bird/components.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass
 from dataclasses import field
 from typing import Any
 
+from django.conf import settings
 from cachetools import LRUCache
 from django.template.backends.django import Template as DjangoTemplate
 from django.template.loader import select_template
@@ -44,7 +45,8 @@ class Registry:
             return self._cache[name]
         except KeyError:
             component = Component.from_name(name)
-            self._cache[name] = component
+            if not settings.DEBUG:
+                self._cache[name] = component
             return component
 
     def clear(self) -> None:

--- a/src/django_bird/components.py
+++ b/src/django_bird/components.py
@@ -4,8 +4,8 @@ from dataclasses import dataclass
 from dataclasses import field
 from typing import Any
 
-from django.conf import settings
 from cachetools import LRUCache
+from django.conf import settings
 from django.template.backends.django import Template as DjangoTemplate
 from django.template.loader import select_template
 

--- a/tests/test_components.py
+++ b/tests/test_components.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import pytest
 from django.template.backends.django import Template
+from django.test import override_settings
 from django.template.exceptions import TemplateDoesNotExist
 
 from django_bird.components import Component
@@ -99,3 +100,17 @@ class TestRegistry:
     def test_component_not_found(self, registry):
         with pytest.raises(TemplateDoesNotExist):
             registry.get_component("nonexistent")
+
+    def test_cache_with_debug(self, registry, create_bird_template):
+        create_bird_template(name="button", content="<button>Click me</button>")
+
+        assert len(registry._cache) == 0
+
+        with override_settings(DEBUG=True):
+            registry.get_component("button")
+
+        assert len(registry._cache) == 0
+
+        registry.get_component("button")
+
+        assert len(registry._cache) == 1

--- a/tests/test_components.py
+++ b/tests/test_components.py
@@ -2,8 +2,8 @@ from __future__ import annotations
 
 import pytest
 from django.template.backends.django import Template
-from django.test import override_settings
 from django.template.exceptions import TemplateDoesNotExist
+from django.test import override_settings
 
 from django_bird.components import Component
 from django_bird.components import Registry


### PR DESCRIPTION
closes #70 