### PR TITLE
:bookmark: bump version 0.6.2 -> 0.7.0

### DIFF
--- a/.copier/package.yml
+++ b/.copier/package.yml
@@ -3,7 +3,7 @@ _commit: v2024.27-4-g3fe659b
 _src_path: /home/josh/projects/work/django-twc-package
 author_email: josh@joshthomas.dev
 author_name: Josh Thomas
-current_version: 0.6.2
+current_version: 0.7.0
 django_versions:
   - "4.2"
   - "5.0"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ and this project attempts to adhere to [Semantic Versioning](https://semver.org/
 
 ## [Unreleased]
 
+## [0.7.0]
+
 ### Changed
 
 - Improved handling of quoted vs unquoted attribute values in `{% bird %}` components. Quoted values (e.g., `class="static-class"`) are treated as literal strings, while unquoted values (e.g., `class=dynamic_class`) are resolved from the template context. This allows for more explicit control over whether an attribute value should be treated as a literal or resolved dynamically.
@@ -127,7 +129,7 @@ and this project attempts to adhere to [Semantic Versioning](https://semver.org/
 
 - Josh Thomas <josh@joshthomas.dev> (maintainer)
 
-[unreleased]: https://github.com/joshuadavidthomas/django-bird/compare/v0.6.2...HEAD
+[unreleased]: https://github.com/joshuadavidthomas/django-bird/compare/v0.7.0...HEAD
 [0.1.0]: https://github.com/joshuadavidthomas/django-bird/releases/tag/v0.1.0
 [0.1.1]: https://github.com/joshuadavidthomas/django-bird/releases/tag/v0.1.1
 [0.2.0]: https://github.com/joshuadavidthomas/django-bird/releases/tag/v0.2.0
@@ -137,3 +139,4 @@ and this project attempts to adhere to [Semantic Versioning](https://semver.org/
 [0.6.0]: https://github.com/joshuadavidthomas/django-bird/releases/tag/v0.6.0
 [0.6.1]: https://github.com/joshuadavidthomas/django-bird/releases/tag/v0.6.1
 [0.6.2]: https://github.com/joshuadavidthomas/django-bird/releases/tag/v0.6.2
+[0.7.0]: https://github.com/joshuadavidthomas/django-bird/releases/tag/v0.7.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,7 +76,7 @@ Source = "https://github.com/joshuadavidthomas/django-bird"
 [tool.bumpver]
 commit = true
 commit_message = ":bookmark: bump version {old_version} -> {new_version}"
-current_version = "0.6.2"
+current_version = "0.7.0"
 push = false  # set to false for CI
 tag = false
 version_pattern = "MAJOR.MINOR.PATCH[PYTAGNUM]"

--- a/src/django_bird/__init__.py
+++ b/src/django_bird/__init__.py
@@ -1,3 +1,3 @@
 from __future__ import annotations
 
-__version__ = "0.6.2"
+__version__ = "0.7.0"

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -4,4 +4,4 @@ from django_bird import __version__
 
 
 def test_version():
-    assert __version__ == "0.6.2"
+    assert __version__ == "0.7.0"

--- a/uv.lock
+++ b/uv.lock
@@ -332,7 +332,7 @@ wheels = [
 
 [[package]]
 name = "django-bird"
-version = "0.6.2"
+version = "0.7.0"
 source = { editable = "." }
 dependencies = [
     { name = "cachetools" },


### PR DESCRIPTION
- `46c7de0`: [pre-commit.ci] pre-commit autoupdate (#74)
- `e6dea0b`: Add quoted vs unquoted value resolution for components (#77)
- `419679c`: add docs and tests for unresolved param variables (#78)
- `ded74f6`: [pre-commit.ci] pre-commit autoupdate (#75)
- `b4f8970`: Bump astral-sh/setup-uv from 4 to 5 in the gha group (#76)
- `b9ae2ed`: simplify asset registry by moving loader attr to global registry (#79)