### PR TITLE
:bookmark: bump version 0.7.2 -> 0.8.0

### DIFF
--- a/.copier/package.yml
+++ b/.copier/package.yml
@@ -3,7 +3,7 @@ _commit: v2024.27-4-g3fe659b
 _src_path: /home/josh/projects/work/django-twc-package
 author_email: josh@joshthomas.dev
 author_name: Josh Thomas
-current_version: 0.7.2
+current_version: 0.8.0
 django_versions:
   - "4.2"
   - "5.0"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ and this project attempts to adhere to [Semantic Versioning](https://semver.org/
 
 ## [Unreleased]
 
+## [0.8.0]
+
 ### Changed
 
 - **Internal**: Consolidated Component and Asset registries into a single `ComponentRegistry`.
@@ -154,7 +156,7 @@ and this project attempts to adhere to [Semantic Versioning](https://semver.org/
 
 - Josh Thomas <josh@joshthomas.dev> (maintainer)
 
-[unreleased]: https://github.com/joshuadavidthomas/django-bird/compare/v0.7.2...HEAD
+[unreleased]: https://github.com/joshuadavidthomas/django-bird/compare/v0.8.0...HEAD
 [0.1.0]: https://github.com/joshuadavidthomas/django-bird/releases/tag/v0.1.0
 [0.1.1]: https://github.com/joshuadavidthomas/django-bird/releases/tag/v0.1.1
 [0.2.0]: https://github.com/joshuadavidthomas/django-bird/releases/tag/v0.2.0
@@ -167,3 +169,4 @@ and this project attempts to adhere to [Semantic Versioning](https://semver.org/
 [0.7.0]: https://github.com/joshuadavidthomas/django-bird/releases/tag/v0.7.0
 [0.7.1]: https://github.com/joshuadavidthomas/django-bird/releases/tag/v0.7.1
 [0.7.2]: https://github.com/joshuadavidthomas/django-bird/releases/tag/v0.7.2
+[0.8.0]: https://github.com/joshuadavidthomas/django-bird/releases/tag/v0.8.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,7 +76,7 @@ Source = "https://github.com/joshuadavidthomas/django-bird"
 [tool.bumpver]
 commit = true
 commit_message = ":bookmark: bump version {old_version} -> {new_version}"
-current_version = "0.7.2"
+current_version = "0.8.0"
 push = false  # set to false for CI
 tag = false
 version_pattern = "MAJOR.MINOR.PATCH[PYTAGNUM]"

--- a/src/django_bird/__init__.py
+++ b/src/django_bird/__init__.py
@@ -1,3 +1,3 @@
 from __future__ import annotations
 
-__version__ = "0.7.2"
+__version__ = "0.8.0"

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -4,4 +4,4 @@ from django_bird import __version__
 
 
 def test_version():
-    assert __version__ == "0.7.2"
+    assert __version__ == "0.8.0"

--- a/uv.lock
+++ b/uv.lock
@@ -332,7 +332,7 @@ wheels = [
 
 [[package]]
 name = "django-bird"
-version = "0.7.2"
+version = "0.8.0"
 source = { editable = "." }
 dependencies = [
     { name = "cachetools" },


### PR DESCRIPTION
- `3d6c035`: remove errant file
- `d50db48`: rename component and asset registries (#86)
- `639204d`: Consolidate asset and component registries (#87)
- `b640f87`: Move component discovery to registry and run at startup (#88)
- `15a8d80`: refactor bird templatetag tests (#89)
- `20f3c50`: refactor components and loader tests for new util dataclasses (#90)
- `15d2f42`: Fix default content fallback behavior in slots (#91)
- `eb2dfac`: refactor other tests to use TestComponent test utils (#92)