### PR TITLE
:bookmark: bump version 0.9.1 -> 0.9.2

### DIFF
--- a/.copier/package.yml
+++ b/.copier/package.yml
@@ -3,7 +3,7 @@ _commit: v2024.27-4-g3fe659b
 _src_path: /home/josh/projects/work/django-twc-package
 author_email: josh@joshthomas.dev
 author_name: Josh Thomas
-current_version: 0.9.1
+current_version: 0.9.2
 django_versions:
   - "4.2"
   - "5.0"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ and this project attempts to adhere to [Semantic Versioning](https://semver.org/
 
 ## [Unreleased]
 
+## [0.9.2]
+
 ### Changed
 
 - Changed component name handling to preserve quotes, allowing literal string names to bypass dynamic resolution (e.g. `{% bird "button" %}` will always use "button" even if `button` exists in the context).
@@ -188,7 +190,7 @@ and this project attempts to adhere to [Semantic Versioning](https://semver.org/
 
 - Josh Thomas <josh@joshthomas.dev> (maintainer)
 
-[unreleased]: https://github.com/joshuadavidthomas/django-bird/compare/v0.9.1...HEAD
+[unreleased]: https://github.com/joshuadavidthomas/django-bird/compare/v0.9.2...HEAD
 [0.1.0]: https://github.com/joshuadavidthomas/django-bird/releases/tag/v0.1.0
 [0.1.1]: https://github.com/joshuadavidthomas/django-bird/releases/tag/v0.1.1
 [0.2.0]: https://github.com/joshuadavidthomas/django-bird/releases/tag/v0.2.0
@@ -206,3 +208,4 @@ and this project attempts to adhere to [Semantic Versioning](https://semver.org/
 [0.8.2]: https://github.com/joshuadavidthomas/django-bird/releases/tag/v0.8.2
 [0.9.0]: https://github.com/joshuadavidthomas/django-bird/releases/tag/v0.9.0
 [0.9.1]: https://github.com/joshuadavidthomas/django-bird/releases/tag/v0.9.1
+[0.9.2]: https://github.com/joshuadavidthomas/django-bird/releases/tag/v0.9.2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -96,7 +96,7 @@ root = "tests"
 [tool.bumpver]
 commit = true
 commit_message = ":bookmark: bump version {old_version} -> {new_version}"
-current_version = "0.9.1"
+current_version = "0.9.2"
 push = false  # set to false for CI
 tag = false
 version_pattern = "MAJOR.MINOR.PATCH[PYTAGNUM]"

--- a/src/django_bird/__init__.py
+++ b/src/django_bird/__init__.py
@@ -1,3 +1,3 @@
 from __future__ import annotations
 
-__version__ = "0.9.1"
+__version__ = "0.9.2"

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -4,4 +4,4 @@ from django_bird import __version__
 
 
 def test_version():
-    assert __version__ == "0.9.1"
+    assert __version__ == "0.9.2"

--- a/uv.lock
+++ b/uv.lock
@@ -332,7 +332,7 @@ wheels = [
 
 [[package]]
 name = "django-bird"
-version = "0.9.1"
+version = "0.9.2"
 source = { editable = "." }
 dependencies = [
     { name = "cachetools" },


### PR DESCRIPTION
- `e0a9e5b`: Modify component name parsing to preserve literal strings (#107)