### PR TITLE
:bookmark: bump version 0.10.3 -> 0.11.0

### DIFF
--- a/.copier/package.yml
+++ b/.copier/package.yml
@@ -3,7 +3,7 @@ _commit: v2024.27-4-g3fe659b
 _src_path: /home/josh/projects/work/django-twc-package
 author_email: josh@joshthomas.dev
 author_name: Josh Thomas
-current_version: 0.10.3
+current_version: 0.11.0
 django_versions:
   - "4.2"
   - "5.0"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ and this project attempts to adhere to [Semantic Versioning](https://semver.org/
 
 ## [Unreleased]
 
+## [0.11.0]
+
 ### Added
 
 - Added `ENABLE_BIRD_ID_ATTR` setting (default: `True`) to control whether components receive an automatic `data-bird-id` attribute. This is to help with component identification in the DOM and for a future planned feature around JS/CSS asset scoping.
@@ -222,7 +224,7 @@ and this project attempts to adhere to [Semantic Versioning](https://semver.org/
 
 - Josh Thomas <josh@joshthomas.dev> (maintainer)
 
-[unreleased]: https://github.com/joshuadavidthomas/django-bird/compare/v0.10.3...HEAD
+[unreleased]: https://github.com/joshuadavidthomas/django-bird/compare/v0.11.0...HEAD
 [0.1.0]: https://github.com/joshuadavidthomas/django-bird/releases/tag/v0.1.0
 [0.1.1]: https://github.com/joshuadavidthomas/django-bird/releases/tag/v0.1.1
 [0.2.0]: https://github.com/joshuadavidthomas/django-bird/releases/tag/v0.2.0
@@ -245,3 +247,4 @@ and this project attempts to adhere to [Semantic Versioning](https://semver.org/
 [0.10.1]: https://github.com/joshuadavidthomas/django-bird/releases/tag/v0.10.1
 [0.10.2]: https://github.com/joshuadavidthomas/django-bird/releases/tag/v0.10.2
 [0.10.3]: https://github.com/joshuadavidthomas/django-bird/releases/tag/v0.10.3
+[0.11.0]: https://github.com/joshuadavidthomas/django-bird/releases/tag/v0.11.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,7 +89,7 @@ root = "tests"
 [tool.bumpver]
 commit = true
 commit_message = ":bookmark: bump version {old_version} -> {new_version}"
-current_version = "0.10.3"
+current_version = "0.11.0"
 push = false  # set to false for CI
 tag = false
 version_pattern = "MAJOR.MINOR.PATCH[PYTAGNUM]"

--- a/src/django_bird/__init__.py
+++ b/src/django_bird/__init__.py
@@ -1,3 +1,3 @@
 from __future__ import annotations
 
-__version__ = "0.10.3"
+__version__ = "0.11.0"

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -4,4 +4,4 @@ from django_bird import __version__
 
 
 def test_version():
-    assert __version__ == "0.10.3"
+    assert __version__ == "0.11.0"

--- a/uv.lock
+++ b/uv.lock
@@ -332,7 +332,7 @@ wheels = [
 
 [[package]]
 name = "django-bird"
-version = "0.10.3"
+version = "0.11.0"
 source = { editable = "." }
 dependencies = [
     { name = "cachetools" },


### PR DESCRIPTION
- `d0805a8`: add test for unused components in asset templatetags (#121)
- `da0ee5e`: refactor asset collection to consistently use `frozenset` (#122)
- `76b2939`: create unique id per component based on name and whitespace normalized source (#123)
- `1c67809`: add component id as data attribute to component attrs (#124)