### PR TITLE
:bookmark: bump version 0.11.1 -> 0.11.2

### DIFF
--- a/.copier/package.yml
+++ b/.copier/package.yml
@@ -3,7 +3,7 @@ _commit: v2024.27-4-g3fe659b
 _src_path: /home/josh/projects/work/django-twc-package
 author_email: josh@joshthomas.dev
 author_name: Josh Thomas
-current_version: 0.11.1
+current_version: 0.11.2
 django_versions:
   - "4.2"
   - "5.0"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ and this project attempts to adhere to [Semantic Versioning](https://semver.org/
 
 ## [Unreleased]
 
+## [0.11.2]
+
 ### Changed
 
 - Improved component context handling by using `Context` objects directly when a component uses the outside template context, instead of flattening the context `dict`.
@@ -236,7 +238,7 @@ and this project attempts to adhere to [Semantic Versioning](https://semver.org/
 
 - Josh Thomas <josh@joshthomas.dev> (maintainer)
 
-[unreleased]: https://github.com/joshuadavidthomas/django-bird/compare/v0.11.1...HEAD
+[unreleased]: https://github.com/joshuadavidthomas/django-bird/compare/v0.11.2...HEAD
 [0.1.0]: https://github.com/joshuadavidthomas/django-bird/releases/tag/v0.1.0
 [0.1.1]: https://github.com/joshuadavidthomas/django-bird/releases/tag/v0.1.1
 [0.2.0]: https://github.com/joshuadavidthomas/django-bird/releases/tag/v0.2.0
@@ -261,3 +263,4 @@ and this project attempts to adhere to [Semantic Versioning](https://semver.org/
 [0.10.3]: https://github.com/joshuadavidthomas/django-bird/releases/tag/v0.10.3
 [0.11.0]: https://github.com/joshuadavidthomas/django-bird/releases/tag/v0.11.0
 [0.11.1]: https://github.com/joshuadavidthomas/django-bird/releases/tag/v0.11.1
+[0.11.2]: https://github.com/joshuadavidthomas/django-bird/releases/tag/v0.11.2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,7 +89,7 @@ root = "tests"
 [tool.bumpver]
 commit = true
 commit_message = ":bookmark: bump version {old_version} -> {new_version}"
-current_version = "0.11.1"
+current_version = "0.11.2"
 push = false  # set to false for CI
 tag = false
 version_pattern = "MAJOR.MINOR.PATCH[PYTAGNUM]"

--- a/src/django_bird/__init__.py
+++ b/src/django_bird/__init__.py
@@ -1,3 +1,3 @@
 from __future__ import annotations
 
-__version__ = "0.11.1"
+__version__ = "0.11.2"

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -4,4 +4,4 @@ from django_bird import __version__
 
 
 def test_version():
-    assert __version__ == "0.11.1"
+    assert __version__ == "0.11.2"

--- a/uv.lock
+++ b/uv.lock
@@ -332,7 +332,7 @@ wheels = [
 
 [[package]]
 name = "django-bird"
-version = "0.11.1"
+version = "0.11.2"
 source = { editable = "." }
 dependencies = [
     { name = "cachetools" },


### PR DESCRIPTION
- `ae03199`: adjust minimum Python version for `main` Django (#130)
- `a0e17c8`: [pre-commit.ci] pre-commit autoupdate (#129)
- `7694c26`: Improve component context handling by using `Context` instead of a flat dict (#131)
- `66c3078`: Normalize component names to use dot separators instead of slashes (#132)