### PR TITLE
:bookmark: bump version 0.12.1 -> 0.13.0

### DIFF
--- a/.copier/package.yml
+++ b/.copier/package.yml
@@ -3,7 +3,7 @@ _commit: v2024.27-4-g3fe659b
 _src_path: /home/josh/projects/work/django-twc-package
 author_email: josh@joshthomas.dev
 author_name: Josh Thomas
-current_version: 0.12.1
+current_version: 0.13.0
 django_versions:
   - "4.2"
   - "5.0"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ and this project attempts to adhere to [Semantic Versioning](https://semver.org/
 
 ## [Unreleased]
 
+## [0.13.0]
+
 🚨 This release contains some breaking changes. See the Deprecated and Removed sections for more information. 🚨
 
 ### Added
@@ -303,7 +305,7 @@ and this project attempts to adhere to [Semantic Versioning](https://semver.org/
 
 - Josh Thomas <josh@joshthomas.dev> (maintainer)
 
-[unreleased]: https://github.com/joshuadavidthomas/django-bird/compare/v0.12.1...HEAD
+[unreleased]: https://github.com/joshuadavidthomas/django-bird/compare/v0.13.0...HEAD
 [0.1.0]: https://github.com/joshuadavidthomas/django-bird/releases/tag/v0.1.0
 [0.1.1]: https://github.com/joshuadavidthomas/django-bird/releases/tag/v0.1.1
 [0.2.0]: https://github.com/joshuadavidthomas/django-bird/releases/tag/v0.2.0
@@ -331,3 +333,4 @@ and this project attempts to adhere to [Semantic Versioning](https://semver.org/
 [0.11.2]: https://github.com/joshuadavidthomas/django-bird/releases/tag/v0.11.2
 [0.12.0]: https://github.com/joshuadavidthomas/django-bird/releases/tag/v0.12.0
 [0.12.1]: https://github.com/joshuadavidthomas/django-bird/releases/tag/v0.12.1
+[0.13.0]: https://github.com/joshuadavidthomas/django-bird/releases/tag/v0.13.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,7 +92,7 @@ root = "tests"
 [tool.bumpver]
 commit = true
 commit_message = ":bookmark: bump version {old_version} -> {new_version}"
-current_version = "0.12.1"
+current_version = "0.13.0"
 push = false  # set to false for CI
 tag = false
 version_pattern = "MAJOR.MINOR.PATCH[PYTAGNUM]"

--- a/src/django_bird/__init__.py
+++ b/src/django_bird/__init__.py
@@ -1,3 +1,3 @@
 from __future__ import annotations
 
-__version__ = "0.12.1"
+__version__ = "0.13.0"

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -4,4 +4,4 @@ from django_bird import __version__
 
 
 def test_version():
-    assert __version__ == "0.12.1"
+    assert __version__ == "0.13.0"

--- a/uv.lock
+++ b/uv.lock
@@ -332,7 +332,7 @@ wheels = [
 
 [[package]]
 name = "django-bird"
-version = "0.12.1"
+version = "0.13.0"
 source = { editable = "." }
 dependencies = [
     { name = "cachetools" },


### PR DESCRIPTION
- `e839dde`: [pre-commit.ci] pre-commit autoupdate (#142)
- `8cc7850`: create `BirdAssetFinder` for integrating `django.contrib.staticfiles` (#143)
- `9e84ab0`: Remove deprecated `ENABLE_BIRD_ID_ATTR` setting and related warnings (#144)
- `6c80bd2`: Add auto-configuration of staticfiles finders (#145)
- `518259d`: add test to cover default settings from `django-admin startproject` (#146)
- `b4e7ce3`: adjust example template fixture
- `a5a7277`: add support for Django 5.2 (#147)
- `d0bcca0`: Refactor `Component` loading strategy in `ComponentRegistry` (#148)
- `ec5b741`: move some utility functions to a `utils` module (#149)
- `78a284f`: remove `django_bird.compiler.Compiler` (#151)
- `39bcceb`: match `BIRD_TAG_PATTERN` regex across newlines (#152)
- `6a83168`: Mark `BirdLoader` as deprecated (#153)
- `7764124`: add breaking change notice to changelog