### PR TITLE
:bookmark: bump version 0.13.0 -> 0.13.1

### DIFF
--- a/.copier/package.yml
+++ b/.copier/package.yml
@@ -3,7 +3,7 @@ _commit: v2024.27-4-g3fe659b
 _src_path: /home/josh/projects/work/django-twc-package
 author_email: josh@joshthomas.dev
 author_name: Josh Thomas
-current_version: 0.13.0
+current_version: 0.13.1
 django_versions:
   - "4.2"
   - "5.0"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@ and this project attempts to adhere to [Semantic Versioning](https://semver.org/
 
 ## [Unreleased]
 
+### Changed
+- **Internal**: Refactored attribute value handling to use pattern matching for cleaner value resolution.
+
 ## [0.13.1]
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,13 @@ and this project attempts to adhere to [Semantic Versioning](https://semver.org/
 
 ### Changed
 - **Internal**: Refactored attribute value handling to use pattern matching for cleaner value resolution.
+- **Internal**: Improved handling of quoted vs unquoted attribute values in component parameters.
+- **Internal**: Simplified template tag parsing in `bird`, `bird:prop`, and `bird:slot` tags.
+- **Internal**: Refactored component parameter handling to be more consistent across the codebase.
+
+### Fixed
+- Fixed asset URL generation to properly use Django's static file storage system instead of raw file paths.
+- Fixed handling of data attributes in components to properly handle quotes and boolean values.
 
 ## [0.13.1]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ and this project attempts to adhere to [Semantic Versioning](https://semver.org/
 
 ## [Unreleased]
 
+## [0.13.1]
+
 ### Fixed
 - Fixed asset URL generation to properly use Django's static file storage system instead of raw file paths.
 
@@ -308,7 +310,7 @@ and this project attempts to adhere to [Semantic Versioning](https://semver.org/
 
 - Josh Thomas <josh@joshthomas.dev> (maintainer)
 
-[unreleased]: https://github.com/joshuadavidthomas/django-bird/compare/v0.13.0...HEAD
+[unreleased]: https://github.com/joshuadavidthomas/django-bird/compare/v0.13.1...HEAD
 [0.1.0]: https://github.com/joshuadavidthomas/django-bird/releases/tag/v0.1.0
 [0.1.1]: https://github.com/joshuadavidthomas/django-bird/releases/tag/v0.1.1
 [0.2.0]: https://github.com/joshuadavidthomas/django-bird/releases/tag/v0.2.0
@@ -337,3 +339,4 @@ and this project attempts to adhere to [Semantic Versioning](https://semver.org/
 [0.12.0]: https://github.com/joshuadavidthomas/django-bird/releases/tag/v0.12.0
 [0.12.1]: https://github.com/joshuadavidthomas/django-bird/releases/tag/v0.12.1
 [0.13.0]: https://github.com/joshuadavidthomas/django-bird/releases/tag/v0.13.0
+[0.13.1]: https://github.com/joshuadavidthomas/django-bird/releases/tag/v0.13.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,20 +18,19 @@ and this project attempts to adhere to [Semantic Versioning](https://semver.org/
 
 ## [Unreleased]
 
+## [0.13.1]
+
 ### Changed
+
 - **Internal**: Refactored attribute value handling to use pattern matching for cleaner value resolution.
 - **Internal**: Improved handling of quoted vs unquoted attribute values in component parameters.
 - **Internal**: Simplified template tag parsing in `bird`, `bird:prop`, and `bird:slot` tags.
 - **Internal**: Refactored component parameter handling to be more consistent across the codebase.
 
 ### Fixed
+
 - Fixed asset URL generation to properly use Django's static file storage system instead of raw file paths.
 - Fixed handling of data attributes in components to properly handle quotes and boolean values.
-
-## [0.13.1]
-
-### Fixed
-- Fixed asset URL generation to properly use Django's static file storage system instead of raw file paths.
 
 ## [0.13.0]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,7 +92,7 @@ root = "tests"
 [tool.bumpver]
 commit = true
 commit_message = ":bookmark: bump version {old_version} -> {new_version}"
-current_version = "0.13.0"
+current_version = "0.13.1"
 push = false  # set to false for CI
 tag = false
 version_pattern = "MAJOR.MINOR.PATCH[PYTAGNUM]"

--- a/src/django_bird/__init__.py
+++ b/src/django_bird/__init__.py
@@ -1,3 +1,3 @@
 from __future__ import annotations
 
-__version__ = "0.13.0"
+__version__ = "0.13.1"

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -4,4 +4,4 @@ from django_bird import __version__
 
 
 def test_version():
-    assert __version__ == "0.13.0"
+    assert __version__ == "0.13.1"

--- a/uv.lock
+++ b/uv.lock
@@ -332,7 +332,7 @@ wheels = [
 
 [[package]]
 name = "django-bird"
-version = "0.13.0"
+version = "0.13.1"
 source = { editable = "." }
 dependencies = [
     { name = "cachetools" },


### PR DESCRIPTION
- `4e69c92`: move `normalize_whitespace` from fixture to utils (#155)
- `31a9672`: Refactor `Value` (#156)
- `2beef61`: refactor Params class constructor to `from_node` (#157)
- `edbc45b`: move `has_nodelist` type guard closer to usage (#158)
- `2f078c9`: move param parsing from `BirdNode` to `Params` constructor (#159)
- `17a5ed4`: refactor and clean up prop templatetag (#160)
- `2c43d96`: refactor and clean up slot templatetag (#161)
- `5a712a6`: [pre-commit.ci] pre-commit autoupdate (#162)
- `13fd278`: add api docs to gitignore
- `8d09f1a`: Update `Asset` to use `StaticFilesStorage` (#165)