### PR TITLE
:bookmark: bump version 0.13.2 -> 0.14.0

### DIFF
--- a/.copier/package.yml
+++ b/.copier/package.yml
@@ -3,7 +3,7 @@ _commit: v2024.27-4-g3fe659b
 _src_path: /home/josh/projects/work/django-twc-package
 author_email: josh@joshthomas.dev
 author_name: Josh Thomas
-current_version: 0.13.2
+current_version: 0.14.0
 django_versions:
   - "4.2"
   - "5.0"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ and this project attempts to adhere to [Semantic Versioning](https://semver.org/
 
 ## [Unreleased]
 
+## [0.14.0]
+
 🚨 This release contains some breaking changes. See the Removed section for more information. 🚨
 
 ### Added
@@ -336,7 +338,7 @@ and this project attempts to adhere to [Semantic Versioning](https://semver.org/
 
 - Josh Thomas <josh@joshthomas.dev> (maintainer)
 
-[unreleased]: https://github.com/joshuadavidthomas/django-bird/compare/v0.13.2...HEAD
+[unreleased]: https://github.com/joshuadavidthomas/django-bird/compare/v0.14.0...HEAD
 [0.1.0]: https://github.com/joshuadavidthomas/django-bird/releases/tag/v0.1.0
 [0.1.1]: https://github.com/joshuadavidthomas/django-bird/releases/tag/v0.1.1
 [0.2.0]: https://github.com/joshuadavidthomas/django-bird/releases/tag/v0.2.0
@@ -367,3 +369,4 @@ and this project attempts to adhere to [Semantic Versioning](https://semver.org/
 [0.13.0]: https://github.com/joshuadavidthomas/django-bird/releases/tag/v0.13.0
 [0.13.1]: https://github.com/joshuadavidthomas/django-bird/releases/tag/v0.13.1
 [0.13.2]: https://github.com/joshuadavidthomas/django-bird/releases/tag/v0.13.2
+[0.14.0]: https://github.com/joshuadavidthomas/django-bird/releases/tag/v0.14.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,7 +92,7 @@ root = "tests"
 [tool.bumpver]
 commit = true
 commit_message = ":bookmark: bump version {old_version} -> {new_version}"
-current_version = "0.13.2"
+current_version = "0.14.0"
 push = false  # set to false for CI
 tag = false
 version_pattern = "MAJOR.MINOR.PATCH[PYTAGNUM]"

--- a/src/django_bird/__init__.py
+++ b/src/django_bird/__init__.py
@@ -1,3 +1,3 @@
 from __future__ import annotations
 
-__version__ = "0.13.2"
+__version__ = "0.14.0"

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -4,4 +4,4 @@ from django_bird import __version__
 
 
 def test_version():
-    assert __version__ == "0.13.2"
+    assert __version__ == "0.14.0"

--- a/uv.lock
+++ b/uv.lock
@@ -332,7 +332,7 @@ wheels = [
 
 [[package]]
 name = "django-bird"
-version = "0.13.2"
+version = "0.14.0"
 source = { editable = "." }
 dependencies = [
     { name = "cachetools" },


### PR DESCRIPTION
- `eb0398e`: Remove debug print statement from template scanning function (#169)
- `8519dfa`: add new `{% bird:var %}` templatetag (#170)
- `ed96eda`: Remove deprecated view-based asset serving and related code (#171)
- `55921f8`: Remove deprecated BirdLoader (#172)
- `83e8e61`: Refactor components, add tests for edge cases, and boost coverage % (#173)