### PR TITLE
:bookmark: bump version 0.14.0 -> 0.14.1

### DIFF
--- a/.copier/package.yml
+++ b/.copier/package.yml
@@ -3,7 +3,7 @@ _commit: v2024.27-4-g3fe659b
 _src_path: /home/josh/projects/work/django-twc-package
 author_email: josh@joshthomas.dev
 author_name: Josh Thomas
-current_version: 0.14.0
+current_version: 0.14.1
 django_versions:
   - "4.2"
   - "5.0"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ and this project attempts to adhere to [Semantic Versioning](https://semver.org/
 
 ## [Unreleased]
 
+## [0.14.1]
+
 ### Fixed
 
 - **Internal**: Removed the double registration of the `{% bird:var %}` and `{% endbird:var %}` tags.
@@ -342,7 +344,7 @@ and this project attempts to adhere to [Semantic Versioning](https://semver.org/
 
 - Josh Thomas <josh@joshthomas.dev> (maintainer)
 
-[unreleased]: https://github.com/joshuadavidthomas/django-bird/compare/v0.14.0...HEAD
+[unreleased]: https://github.com/joshuadavidthomas/django-bird/compare/v0.14.1...HEAD
 [0.1.0]: https://github.com/joshuadavidthomas/django-bird/releases/tag/v0.1.0
 [0.1.1]: https://github.com/joshuadavidthomas/django-bird/releases/tag/v0.1.1
 [0.2.0]: https://github.com/joshuadavidthomas/django-bird/releases/tag/v0.2.0
@@ -374,3 +376,4 @@ and this project attempts to adhere to [Semantic Versioning](https://semver.org/
 [0.13.1]: https://github.com/joshuadavidthomas/django-bird/releases/tag/v0.13.1
 [0.13.2]: https://github.com/joshuadavidthomas/django-bird/releases/tag/v0.13.2
 [0.14.0]: https://github.com/joshuadavidthomas/django-bird/releases/tag/v0.14.0
+[0.14.1]: https://github.com/joshuadavidthomas/django-bird/releases/tag/v0.14.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,7 +92,7 @@ root = "tests"
 [tool.bumpver]
 commit = true
 commit_message = ":bookmark: bump version {old_version} -> {new_version}"
-current_version = "0.14.0"
+current_version = "0.14.1"
 push = false  # set to false for CI
 tag = false
 version_pattern = "MAJOR.MINOR.PATCH[PYTAGNUM]"

--- a/src/django_bird/__init__.py
+++ b/src/django_bird/__init__.py
@@ -1,3 +1,3 @@
 from __future__ import annotations
 
-__version__ = "0.14.0"
+__version__ = "0.14.1"

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -4,4 +4,4 @@ from django_bird import __version__
 
 
 def test_version():
-    assert __version__ == "0.14.0"
+    assert __version__ == "0.14.1"

--- a/uv.lock
+++ b/uv.lock
@@ -182,7 +182,7 @@ name = "click"
 version = "8.1.8"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "colorama", marker = "platform_system == 'Windows'" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/b9/2e/0090cbf739cee7d23781ad4b89a9894a41538e4fcf4c31dcdd705b78eb8b/click-8.1.8.tar.gz", hash = "sha256:ed53c9d8990d83c2a27deae68e4ee337473f6330c040a31d4225c9574d16096a", size = 226593 }
 wheels = [
@@ -344,7 +344,6 @@ wheels = [
 
 [[package]]
 name = "django-bird"
-version = "0.14.0"
 source = { editable = "." }
 dependencies = [
     { name = "cachetools" },
@@ -830,7 +829,7 @@ name = "plumbum"
 version = "1.9.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pywin32", marker = "platform_python_implementation != 'PyPy' and platform_system == 'Windows'" },
+    { name = "pywin32", marker = "platform_python_implementation != 'PyPy' and sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/f0/5d/49ba324ad4ae5b1a4caefafbce7a1648540129344481f2ed4ef6bb68d451/plumbum-1.9.0.tar.gz", hash = "sha256:e640062b72642c3873bd5bdc3effed75ba4d3c70ef6b6a7b907357a84d909219", size = 319083 }
 wheels = [


### PR DESCRIPTION
- `ef5baa2`: bump uv lock
- `c6ba808`: remove double registration of var tags (#175)