### PR TITLE
:bookmark: bump version 0.14.1 -> 0.14.2

### DIFF
--- a/.copier/package.yml
+++ b/.copier/package.yml
@@ -3,7 +3,7 @@ _commit: v2024.27-4-g3fe659b
 _src_path: /home/josh/projects/work/django-twc-package
 author_email: josh@joshthomas.dev
 author_name: Josh Thomas
-current_version: 0.14.1
+current_version: 0.14.2
 django_versions:
   - "4.2"
   - "5.0"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ and this project attempts to adhere to [Semantic Versioning](https://semver.org/
 
 ## [Unreleased]
 
+## [0.14.2]
+
 ### Changed
 
 - **Internal**: Created `BirdAssetStorage` to handle static file storage with custom prefixes and future CSS and JS scoping.
@@ -354,7 +356,7 @@ and this project attempts to adhere to [Semantic Versioning](https://semver.org/
 
 - Josh Thomas <josh@joshthomas.dev> (maintainer)
 
-[unreleased]: https://github.com/joshuadavidthomas/django-bird/compare/v0.14.1...HEAD
+[unreleased]: https://github.com/joshuadavidthomas/django-bird/compare/v0.14.2...HEAD
 [0.1.0]: https://github.com/joshuadavidthomas/django-bird/releases/tag/v0.1.0
 [0.1.1]: https://github.com/joshuadavidthomas/django-bird/releases/tag/v0.1.1
 [0.2.0]: https://github.com/joshuadavidthomas/django-bird/releases/tag/v0.2.0
@@ -387,3 +389,4 @@ and this project attempts to adhere to [Semantic Versioning](https://semver.org/
 [0.13.2]: https://github.com/joshuadavidthomas/django-bird/releases/tag/v0.13.2
 [0.14.0]: https://github.com/joshuadavidthomas/django-bird/releases/tag/v0.14.0
 [0.14.1]: https://github.com/joshuadavidthomas/django-bird/releases/tag/v0.14.1
+[0.14.2]: https://github.com/joshuadavidthomas/django-bird/releases/tag/v0.14.2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ dev = [
   "pytest-django>=4.9.0",
   "pytest-randomly>=3.15.0",
   "pytest-xdist>=3.6.1",
-  "ruff>=0.6.6",
+  "ruff>=0.6.6"
 ]
 docs = [
   "furo>=2024.8.6",
@@ -26,17 +26,17 @@ docs = [
   "sphinx-autobuild>=2024.10.3",
   "sphinx-autodoc2>=0.5.0",
   "sphinx-copybutton>=0.5.2",
-  "sphinx-inline-tabs>=2023.4.21",
+  "sphinx-inline-tabs>=2023.4.21"
 ]
 types = [
   "django-stubs>=5.1.0",
   "django-stubs-ext>=5.1.0",
   "mypy>=1.11.2",
-  "types-cachetools>=5.5.0.20240820",
+  "types-cachetools>=5.5.0.20240820"
 ]
 
 [project]
-authors = [{ name = "Josh Thomas", email = "josh@joshthomas.dev" }]
+authors = [{name = "Josh Thomas", email = "josh@joshthomas.dev"}]
 classifiers = [
   "Development Status :: 3 - Alpha",
   "Framework :: Django",
@@ -53,13 +53,13 @@ classifiers = [
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13",
-  "Programming Language :: Python :: Implementation :: CPython",
+  "Programming Language :: Python :: Implementation :: CPython"
 ]
 dependencies = ["cachetools>=5.5.0", "django>=4.2"]
 description = "High-flying components for perfectionists with deadlines"
 dynamic = ["version"]
 keywords = []
-license = { file = "LICENSE" }
+license = {file = "LICENSE"}
 name = "django-bird"
 readme = "README.md"
 requires-python = ">=3.10"
@@ -112,7 +112,7 @@ exclude_lines = [
   "if not DEBUG:",
   "if settings.DEBUG:",
   "if TYPE_CHECKING:",
-  'def __str__\(self\)\s?\-?\>?\s?\w*\:',
+  'def __str__\(self\)\s?\-?\>?\s?\w*\:'
 ]
 fail_under = 98
 
@@ -120,8 +120,8 @@ fail_under = 98
 omit = [
   "src/django_bird/migrations/*",
   "src/django_bird/_typing.py",
-  "src/django_bird/views.py",     # TODO: remove when not empty
-  "tests/*",
+  "src/django_bird/views.py",  # TODO: remove when not empty
+  "tests/*"
 ]
 source = ["src/django_bird"]
 
@@ -133,7 +133,7 @@ strict_settings = false
 blank_line_after_tag = "endblock,endpartialdef,extends,load"
 blank_line_before_tag = "block,partialdef"
 custom_blocks = "bird,bird:slot,partialdef"
-ignore = "H031"                                              # Don't require `meta` tag keywords
+ignore = "H031"  # Don't require `meta` tag keywords
 indent = 2
 profile = "django"
 
@@ -193,7 +193,7 @@ exclude = [
   "dist",
   "migrations",
   "node_modules",
-  "venv",
+  "venv"
 ]
 extend-include = ["*.pyi?"]
 indent-width = 4
@@ -215,13 +215,13 @@ quote-style = "double"
 dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
 # Allow autofix for all enabled rules (when `--fix`) is provided.
 fixable = ["A", "B", "C", "D", "E", "F", "I"]
-ignore = ["E501", "E741"] # temporary
+ignore = ["E501", "E741"]  # temporary
 select = [
   "B",  # flake8-bugbear
   "E",  # Pycodestyle
   "F",  # Pyflakes
   "I",  # isort
-  "UP", # pyupgrade
+  "UP"  # pyupgrade
 ]
 unfixable = []
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,8 +92,8 @@ root = "tests"
 [tool.bumpver]
 commit = true
 commit_message = ":bookmark: bump version {old_version} -> {new_version}"
-current_version = "0.14.1"
-push = false                                                              # set to false for CI
+current_version = "0.14.2"
+push = false  # set to false for CI
 tag = false
 version_pattern = "MAJOR.MINOR.PATCH[PYTAGNUM]"
 

--- a/src/django_bird/__init__.py
+++ b/src/django_bird/__init__.py
@@ -1,3 +1,3 @@
 from __future__ import annotations
 
-__version__ = "0.14.1"
+__version__ = "0.14.2"

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -4,4 +4,4 @@ from django_bird import __version__
 
 
 def test_version():
-    assert __version__ == "0.14.1"
+    assert __version__ == "0.14.2"


### PR DESCRIPTION
- `6b38965`: [pre-commit.ci] pre-commit autoupdate (#179)
- `e527a73`: fix uv required version
- `48680fa`: bump uv lock deps
- `2611d3e`: create `BirdAssetStorage` (#180)
- `cff112c`: Fix scanning of templates for component usage (#183)
- `734a859`: update changelog