### PR TITLE
:bookmark: bump version 0.14.2 -> 0.15.0

### DIFF
--- a/.copier/package.yml
+++ b/.copier/package.yml
@@ -3,7 +3,7 @@ _commit: v2024.27-4-g3fe659b
 _src_path: /home/josh/projects/work/django-twc-package
 author_email: josh@joshthomas.dev
 author_name: Josh Thomas
-current_version: 0.14.2
+current_version: 0.15.0
 django_versions:
   - "4.2"
   - "5.0"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ and this project attempts to adhere to [Semantic Versioning](https://semver.org/
 
 ## [Unreleased]
 
+## [0.15.0]
+
 ### Added
 
 - Added plugin system infrastructure using `pluggy`.
@@ -366,7 +368,7 @@ and this project attempts to adhere to [Semantic Versioning](https://semver.org/
 
 - Josh Thomas <josh@joshthomas.dev> (maintainer)
 
-[unreleased]: https://github.com/joshuadavidthomas/django-bird/compare/v0.14.2...HEAD
+[unreleased]: https://github.com/joshuadavidthomas/django-bird/compare/v0.15.0...HEAD
 [0.1.0]: https://github.com/joshuadavidthomas/django-bird/releases/tag/v0.1.0
 [0.1.1]: https://github.com/joshuadavidthomas/django-bird/releases/tag/v0.1.1
 [0.2.0]: https://github.com/joshuadavidthomas/django-bird/releases/tag/v0.2.0
@@ -400,3 +402,4 @@ and this project attempts to adhere to [Semantic Versioning](https://semver.org/
 [0.14.0]: https://github.com/joshuadavidthomas/django-bird/releases/tag/v0.14.0
 [0.14.1]: https://github.com/joshuadavidthomas/django-bird/releases/tag/v0.14.1
 [0.14.2]: https://github.com/joshuadavidthomas/django-bird/releases/tag/v0.14.2
+[0.15.0]: https://github.com/joshuadavidthomas/django-bird/releases/tag/v0.15.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -98,7 +98,7 @@ root = "tests"
 [tool.bumpver]
 commit = true
 commit_message = ":bookmark: bump version {old_version} -> {new_version}"
-current_version = "0.14.2"
+current_version = "0.15.0"
 push = false  # set to false for CI
 tag = false
 version_pattern = "MAJOR.MINOR.PATCH[PYTAGNUM]"

--- a/src/django_bird/__init__.py
+++ b/src/django_bird/__init__.py
@@ -2,6 +2,6 @@ from __future__ import annotations
 
 from pluggy import HookimplMarker
 
-__version__ = "0.14.2"
+__version__ = "0.15.0"
 
 hookimpl = HookimplMarker("django_bird")

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -4,4 +4,4 @@ from django_bird import __version__
 
 
 def test_version():
-    assert __version__ == "0.14.2"
+    assert __version__ == "0.15.0"


### PR DESCRIPTION
- `70ea87f`: Scaffold out plugin system using `pluggy` (#185)
- `cce4605`: Refactor asset collection to new internal plugin (#186)
- `1b2b49f`: remove unneeded type checking import
- `408f101`: move internal plugin back to `staticfiles` module (#187)
- `87dae23`: Add documentation for plugins (#188)
- `deb32bb`: add loading of plugin entry points