### PR TITLE
fix performance of `BirdAssetFinder.find` by removing component discovery scan

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ and this project attempts to adhere to [Semantic Versioning](https://semver.org/
 
 ## [Unreleased]
 
+🚨 This release contains some breaking changes. See the Changed section for more information. 🚨
+
 ### Added
 
 - Added `AssetTypes` registry to manage different types of component assets.
@@ -29,6 +31,11 @@ and this project attempts to adhere to [Semantic Versioning](https://semver.org/
 - **Internal**: Refactored `AssetType` from an `Enum` to a `dataclass`, to allow for creating new types of assets to register with the library.
 - **Internal**: Replaced `LRUCache` with standard dict in `ComponentRegistry`, removing the `cachetools` dependency.
 - **Internal**: Refactored template directory discovery to use plugin system, moving Django's default engine and app template directory handling to a new `django_bird.templates` plugin.
+- **Breaking**: `BirdAssetFinder.find` now returns files from all component directories that match the requested path. Previously it incorrectly applied component template resolution precedence rules to static file paths.
+
+### Fixed
+
+- Improved performance by removing component discovery scanning from `BirdAssetFinder.find`.
 
 ## [0.15.0]
 

--- a/tests/test_staticfiles.py
+++ b/tests/test_staticfiles.py
@@ -380,15 +380,15 @@ class TestFindersFind:
         assert finders.find("bird/button.js") == str(button_js.file)
 
     def test_find_asset_custom_dir(self, templates_dir, override_app_settings):
-        button = TestComponent(
+        bird_button = TestComponent(
             name="button", content="<button>Click me</button>"
         ).create(templates_dir)
         custom_button = TestComponent(
             name="button", content="<button>Click me</button>", parent_dir="components"
         ).create(templates_dir)
 
-        TestAsset(
-            component=button,
+        bird_button_css = TestAsset(
+            component=bird_button,
             content=".button { color: blue; }",
             asset_type=CSS,
         ).create()
@@ -399,10 +399,8 @@ class TestFindersFind:
         ).create()
 
         with override_app_settings(COMPONENT_DIRS=["components"]):
-            # components are matched like templates, dirs in
-            # `settings.DJANGO_BIRD["COMPONENT_DIRS"]` take precedence
             assert finders.find("components/button.css") == str(custom_button_css.file)
-            assert finders.find("bird/button.css") is None
+            assert finders.find("bird/button.css") == str(bird_button_css.file)
 
     def test_find_nested_asset(self, templates_dir):
         button = TestComponent(


### PR DESCRIPTION
ref #194 