### PR TITLE
:bookmark: bump version 0.16.0 -> 0.16.1

### DIFF
--- a/.copier/package.yml
+++ b/.copier/package.yml
@@ -3,7 +3,7 @@ _commit: v2024.27-4-g3fe659b
 _src_path: /home/josh/projects/work/django-twc-package
 author_email: josh@joshthomas.dev
 author_name: Josh Thomas
-current_version: 0.16.0
+current_version: 0.16.1
 django_versions:
   - "4.2"
   - "5.0"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ and this project attempts to adhere to [Semantic Versioning](https://semver.org/
 
 ## [Unreleased]
 
+## [0.16.1]
+
 ### Added
 
 - Added new plugin hook `ready` for handling application initialization during Django's application ready phase.
@@ -405,7 +407,7 @@ and this project attempts to adhere to [Semantic Versioning](https://semver.org/
 
 - Josh Thomas <josh@joshthomas.dev> (maintainer)
 
-[unreleased]: https://github.com/joshuadavidthomas/django-bird/compare/v0.16.0...HEAD
+[unreleased]: https://github.com/joshuadavidthomas/django-bird/compare/v0.16.1...HEAD
 [0.1.0]: https://github.com/joshuadavidthomas/django-bird/releases/tag/v0.1.0
 [0.1.1]: https://github.com/joshuadavidthomas/django-bird/releases/tag/v0.1.1
 [0.2.0]: https://github.com/joshuadavidthomas/django-bird/releases/tag/v0.2.0
@@ -441,3 +443,4 @@ and this project attempts to adhere to [Semantic Versioning](https://semver.org/
 [0.14.2]: https://github.com/joshuadavidthomas/django-bird/releases/tag/v0.14.2
 [0.15.0]: https://github.com/joshuadavidthomas/django-bird/releases/tag/v0.15.0
 [0.16.0]: https://github.com/joshuadavidthomas/django-bird/releases/tag/v0.16.0
+[0.16.1]: https://github.com/joshuadavidthomas/django-bird/releases/tag/v0.16.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -103,7 +103,7 @@ root = "tests"
 [tool.bumpver]
 commit = true
 commit_message = ":bookmark: bump version {old_version} -> {new_version}"
-current_version = "0.16.0"
+current_version = "0.16.1"
 push = false  # set to false for CI
 tag = false
 version_pattern = "MAJOR.MINOR.PATCH[PYTAGNUM]"

--- a/src/django_bird/__init__.py
+++ b/src/django_bird/__init__.py
@@ -2,6 +2,6 @@ from __future__ import annotations
 
 from pluggy import HookimplMarker
 
-__version__ = "0.16.0"
+__version__ = "0.16.1"
 
 hookimpl = HookimplMarker("django_bird")

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -4,4 +4,4 @@ from django_bird import __version__
 
 
 def test_version():
-    assert __version__ == "0.16.0"
+    assert __version__ == "0.16.1"


### PR DESCRIPTION
- `38f82b3`: adjust type module path
- `1f90357`: Add `ready` plugin hook and refactor library init to internal plugin (#198)
- `ccc3941`: change ready hook to just autoconfiguration (#199)
- `0fba670`: remove app_settings arg from ready hook (#200)
- `2d16d7b`: rename variable
- `615596d`: deprecate autoconfiguration, pending move to dedicated plugin (#201)
- `1385e85`: adjust type checking infrastructure a bit (#202)