### PR TITLE
add new `pre_ready` hook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ and this project attempts to adhere to [Semantic Versioning](https://semver.org/
 
 ## [Unreleased]
 
+### Added
+
+- Added new plugin hook `pre_ready` for handling initialization of library, but run before any internal setup. Needed for django-bird-autoconf to autoconfigure projects, e.g, add to template builtins.
+
 ## [0.16.1]
 
 ### Added

--- a/src/django_bird/apps.py
+++ b/src/django_bird/apps.py
@@ -19,7 +19,11 @@ class DjangoBirdAppConfig(AppConfig):
         from django_bird.plugins import pm
         from django_bird.staticfiles import asset_types
 
+        for pre_ready in pm.hook.pre_ready():
+            pre_ready()
+
         pm.hook.register_asset_types(register_type=asset_types.register_type)
         components.discover_components()
+
         for ready in pm.hook.ready():
             ready()

--- a/src/django_bird/plugins/hookspecs.py
+++ b/src/django_bird/plugins/hookspecs.py
@@ -38,12 +38,29 @@ def get_template_directories() -> list[Path]:
 
 
 @hookspec
-def ready() -> None:
-    """Called when the django-bird application is ready.
+def pre_ready() -> None:
+    """Called before django-bird begins its internal setup.
 
-    This hook is called during Django's application ready phase, allowing plugins to perform
-    necessary setup like configuring settings, registering features, or any other
-    initialization tasks.
+    This hook runs at the start of django-bird's initialization, before any internal
+    components are configured or discovered. Plugins can use this hook to perform early
+    configuration of:
+
+    - Django settings
+    - Template directories
+    - Template builtins
+    """
+
+
+@hookspec
+def ready() -> None:
+    """Called after django-bird application has completed its internal setup and is ready.
+
+    This hook is called during Django's application ready phase, after django-bird's own
+    initialization is complete. Plugins can:
+
+    - Access fully configured components
+    - Register additional features that depend on django-bird being ready
+    - Perform cleanup or post-initialization tasks
     """
 
 


### PR DESCRIPTION
oops! autoconf can't work unless it sets up the builtins before component discovery