### PR TITLE
Add component domain utilities for asset manifest optimization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ and this project attempts to adhere to [Semantic Versioning](https://semver.org/
 
 ## [Unreleased]
 
+### Added
+
+- Added `get_component_names_used_in_template` method to ComponentRegistry to access component names used in a template
+
 ## [0.16.2]
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project attempts to adhere to [Semantic Versioning](https://semver.org/
 ### Added
 
 - Added `get_component_names_used_in_template` method to ComponentRegistry to access component names used in a template
+- Added `get_component_assets` utility function to staticfiles.py to get assets for a component with optional filtering
 
 ## [0.16.2]
 

--- a/src/django_bird/components.py
+++ b/src/django_bird/components.py
@@ -223,11 +223,18 @@ class ComponentRegistry:
             self._component_usage[name] = set()
         return self._components[name]
 
+    def get_component_names_used_in_template(
+        self, template_path: str | Path
+    ) -> set[str]:
+        """Get names of components used in a template."""
+        path = Path(template_path) if isinstance(template_path, str) else template_path
+        return self._template_usage.get(path, set())
+
     def get_component_usage(
         self, template_path: str | Path
     ) -> Generator[Component, Any, None]:
-        path = Path(template_path) if isinstance(template_path, str) else template_path
-        for component_name in self._template_usage.get(path, set()):
+        """Get components used in a template."""
+        for component_name in self.get_component_names_used_in_template(template_path):
             yield Component.from_name(component_name)
 
 

--- a/src/django_bird/staticfiles.py
+++ b/src/django_bird/staticfiles.py
@@ -6,6 +6,7 @@ from collections.abc import Sequence
 from dataclasses import dataclass
 from enum import Enum
 from pathlib import Path
+from typing import TYPE_CHECKING
 from typing import Any
 from typing import Literal
 from typing import final
@@ -24,6 +25,9 @@ from .apps import DjangoBirdAppConfig
 from .conf import app_settings
 from .templates import get_component_directories
 from .templatetags.tags.asset import AssetTag
+
+if TYPE_CHECKING:
+    from .components import Component
 
 
 class AssetElement(Enum):
@@ -140,6 +144,24 @@ def collect_component_assets(template_path: Path) -> Iterable[Asset]:
         asset_path = template_path.with_suffix(asset_type.suffix)
         if asset_path.exists():
             assets.append(Asset(path=asset_path, type=asset_type))
+    return assets
+
+
+def get_component_assets(
+    component: Component, asset_type: str | None = None
+) -> list[Asset]:
+    """Get assets for a component, optionally filtered by type.
+
+    Args:
+        component: The component to get assets for
+        asset_type: Optional asset type extension to filter by (e.g., "css", "js")
+
+    Returns:
+        A list of assets for the component, filtered by type if specified
+    """
+    assets = list(component.assets)
+    if asset_type:
+        assets = [a for a in assets if a.type.extension == asset_type]
     return assets
 
 


### PR DESCRIPTION
Refs #207 

## Summary
This PR adds necessary groundwork for the asset discovery optimization:

- Added `get_component_names_used_in_template` method to ComponentRegistry to access raw component names
- Added `get_component_assets` utility function to staticfiles.py for filtering assets by type

These changes are part of the domain separation refactoring to prepare for implementing the adding an asset manifest optimization.