### PR TITLE
Remove component discovery at startup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,14 @@ and this project attempts to adhere to [Semantic Versioning](https://semver.org/
 - Added management command `generate_asset_manifest` for pre-computing template-component relationships
 - Added automatic fallback to component scanning in development mode (when DEBUG=True)
 
+### Changed
+
+- Improved static file collection to include assets from all component directories
+
+### Fixed
+
+- Fixed bug where assets from components with the same name in different directories weren't being properly collected
+
 ### Removed
 
 - Removed automatic component scanning at application startup for faster initialization

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ and this project attempts to adhere to [Semantic Versioning](https://semver.org/
 ### Removed
 
 - Removed automatic component scanning at application startup for faster initialization
+- **Internal**: Removed `ComponentRegistry.discover_components` method.
 
 ## [0.16.2]
 

--- a/tests/templatetags/test_asset.py
+++ b/tests/templatetags/test_asset.py
@@ -98,8 +98,6 @@ class TestTemplateTag:
             {% endblock %}
         """)
 
-        registry.discover_components()
-
         template = create_template(child_path)
 
         rendered = template.render({})
@@ -150,8 +148,6 @@ class TestTemplateTag:
                 No bird component here!
             {% endblock %}
         """)
-
-        registry.discover_components()
 
         template = create_template(child_path)
 
@@ -230,8 +226,6 @@ class TestTemplateTag:
             </html>
         """)
 
-        registry.discover_components()
-
         template = create_template(template_path)
 
         rendered = template.render({})
@@ -293,8 +287,6 @@ class TestTemplateTag:
                 {% bird alert %}Base Alert{% endbird %}
             {% endblock %}
         """)
-
-        registry.discover_components()
 
         template = get_template(child_path.name)
 
@@ -359,8 +351,6 @@ class TestTemplateTag:
             {% endblock %}
         """)
 
-        registry.discover_components()
-
         template = create_template(child_path)
 
         rendered = template.render({})
@@ -424,8 +414,6 @@ class TestManifest:
         </html>
         """)
 
-        registry.discover_components()
-
         manifest_data = generate_asset_manifest()
 
         manifest_path = static_root / "django_bird"
@@ -466,8 +454,6 @@ class TestManifest:
         </body>
         </html>
         """)
-
-        registry.discover_components()
 
         manifest_data = {"not/a/real/template.html": ["not-button"]}
 
@@ -515,8 +501,6 @@ class TestManifest:
         other_path.write_text("""
         <html><body>Other template</body></html>
         """)
-
-        registry.discover_components()
 
         manifest_data = {str(other_path): ["button"]}
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -2,12 +2,8 @@ from __future__ import annotations
 
 from django.template.loader import get_template
 
-from django_bird.components import components
-
 
 def test_template_inheritance_assets(example_template):
-    components.discover_components()
-
     rendered = get_template(example_template.template.name).render({})
 
     assert all(

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -179,8 +179,6 @@ def test_generate_asset_manifest(templates_dir, registry):
         templates_dir
     )
 
-    registry.discover_components()
-
     manifest = generate_asset_manifest()
 
     all_keys = list(manifest.keys())
@@ -222,9 +220,7 @@ def test_default_manifest_path():
 class TestManagementCommand:
     """Tests for the generate_asset_manifest management command."""
 
-    def test_generate_asset_manifest_command_default(
-        self, static_root, templates_dir, registry
-    ):
+    def test_generate_asset_manifest_command_default(self, static_root, templates_dir):
         TestComponent(name="test_cmd", content="<div>{{ slot }}</div>").create(
             templates_dir
         )
@@ -237,8 +233,6 @@ class TestManagementCommand:
         </body>
         </html>
         """)
-
-        registry.discover_components()
 
         stdout = StringIO()
 
@@ -261,7 +255,7 @@ class TestManagementCommand:
         assert "test_cmd" in manifest_data[template_keys[0]]
 
     def test_generate_asset_manifest_command_with_options(
-        self, tmp_path, templates_dir, registry
+        self, tmp_path, templates_dir
     ):
         TestComponent(name="test_cmd2", content="<div>{{ slot }}</div>").create(
             templates_dir
@@ -275,8 +269,6 @@ class TestManagementCommand:
         </body>
         </html>
         """)
-
-        registry.discover_components()
 
         custom_output = tmp_path / "custom" / "manifest.json"
 

--- a/tests/test_staticfiles.py
+++ b/tests/test_staticfiles.py
@@ -335,7 +335,9 @@ class TestBirdAssetFinder:
             name="button", content="<button>Click me</button>"
         ).create(templates_dir)
         custom_button = TestComponent(
-            name="button", content="<button>Click me</button>", parent_dir="components"
+            name="button",
+            content="<button>Click me</button>",
+            parent_dir="components",
         ).create(templates_dir)
 
         button_css = TestAsset(
@@ -354,11 +356,12 @@ class TestBirdAssetFinder:
         with override_app_settings(COMPONENT_DIRS=["components"]):
             listed_assets = list(finder.list(None))
 
-        assert len(listed_assets) == 1
-        # components are matched like templates, dirs in
-        # `settings.DJANGO_BIRD["COMPONENT_DIRS"]` take precedence
-        assert listed_assets[0][0] in str(custom_button_css.file)
-        assert listed_assets[0][0] not in str(button_css.file)
+        assert len(listed_assets) == 2
+
+        asset_files = [asset_tuple[0] for asset_tuple in listed_assets]
+
+        assert str(button_css.relative_file_path) in asset_files
+        assert str(custom_button_css.relative_file_path) in asset_files
 
 
 class TestFindersFind:
@@ -522,10 +525,10 @@ class TestStaticCollection:
         with override_app_settings(COMPONENT_DIRS=["components"]):
             call_command("collectstatic", interactive=False, verbosity=0)
 
-            # components are matched like templates, dirs in
-            # `settings.DJANGO_BIRD["COMPONENT_DIRS"]` take precedence
+            # Both assets should be collected - all components exist on disk
+            # and should have their assets available
             assert (static_root / "django_bird/components/button.css").exists()
-            assert not (static_root / "django_bird/bird/button.css").exists()
+            assert (static_root / "django_bird/bird/button.css").exists()
 
     def test_same_named_assets(self, templates_dir, static_root):
         button1 = TestComponent(

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -60,6 +60,13 @@ class TestAsset:
 
         return self
 
+    @property
+    def relative_file_path(self):
+        component_dir = Path(self.component.parent_dir)
+        if self.component.sub_dir:
+            component_dir = component_dir / self.component.sub_dir
+        return Path(component_dir / self.file.name)
+
 
 @dataclass
 class TestComponentCase:


### PR DESCRIPTION
This change removes the upfront component discovery at application startup and replaces it with on-demand discovery when templates are rendered. This should significantly improve startup performance for applications with many components.

Key changes:
- Remove ComponentRegistry.discover_components() method
- Update get_component_names_used_in_template() to perform on-demand scanning
- Add find_components_in_template() function for template scanning
- Update BirdAssetFinder to scan components directly when needed
- Update tests to work with on-demand component discovery