### PR TITLE
Log any potential encoding errors in template scanning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ and this project attempts to adhere to [Semantic Versioning](https://semver.org/
 ### Fixed
 
 - Fixed bug where assets from components with the same name in different directories weren't being properly collected
+- Fixed template scanning on some platforms by improving error handling for invalid template files
 
 ### Removed
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -254,4 +254,4 @@ required-imports = ["from __future__ import annotations"]
 keep-runtime-typing = true
 
 [tool.uv]
-required-version = "==0.6.*"
+required-version = "~=0.6"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -254,4 +254,4 @@ required-imports = ["from __future__ import annotations"]
 keep-runtime-typing = true
 
 [tool.uv]
-required-version = "~=0.6"
+required-version = "<0.7"


### PR DESCRIPTION
@williln Adding this since I can't recreate that specific error, I assume something MacOS or platform specific? If nothing else, this won't crash your dev server. 😅