### PR TITLE
:bookmark: bump version 0.16.2 -> 0.17.0

### DIFF
--- a/.copier/package.yml
+++ b/.copier/package.yml
@@ -3,7 +3,7 @@ _commit: v2024.27-4-g3fe659b
 _src_path: /home/josh/projects/work/django-twc-package
 author_email: josh@joshthomas.dev
 author_name: Josh Thomas
-current_version: 0.16.2
+current_version: 0.17.0
 django_versions:
   - "4.2"
   - "5.0"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ and this project attempts to adhere to [Semantic Versioning](https://semver.org/
 
 ## [Unreleased]
 
+## [0.17.0]
+
 🚨 This release contains some breaking changes. See the Removed section for more information. 🚨
 
 ### Added
@@ -444,7 +446,7 @@ and this project attempts to adhere to [Semantic Versioning](https://semver.org/
 
 - Josh Thomas <josh@joshthomas.dev> (maintainer)
 
-[unreleased]: https://github.com/joshuadavidthomas/django-bird/compare/v0.16.2...HEAD
+[unreleased]: https://github.com/joshuadavidthomas/django-bird/compare/v0.17.0...HEAD
 [0.1.0]: https://github.com/joshuadavidthomas/django-bird/releases/tag/v0.1.0
 [0.1.1]: https://github.com/joshuadavidthomas/django-bird/releases/tag/v0.1.1
 [0.2.0]: https://github.com/joshuadavidthomas/django-bird/releases/tag/v0.2.0
@@ -482,3 +484,4 @@ and this project attempts to adhere to [Semantic Versioning](https://semver.org/
 [0.16.0]: https://github.com/joshuadavidthomas/django-bird/releases/tag/v0.16.0
 [0.16.1]: https://github.com/joshuadavidthomas/django-bird/releases/tag/v0.16.1
 [0.16.2]: https://github.com/joshuadavidthomas/django-bird/releases/tag/v0.16.2
+[0.17.0]: https://github.com/joshuadavidthomas/django-bird/releases/tag/v0.17.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -103,7 +103,7 @@ root = "tests"
 [tool.bumpver]
 commit = true
 commit_message = ":bookmark: bump version {old_version} -> {new_version}"
-current_version = "0.16.2"
+current_version = "0.17.0"
 push = false  # set to false for CI
 tag = false
 version_pattern = "MAJOR.MINOR.PATCH[PYTAGNUM]"

--- a/src/django_bird/__init__.py
+++ b/src/django_bird/__init__.py
@@ -2,6 +2,6 @@ from __future__ import annotations
 
 from pluggy import HookimplMarker
 
-__version__ = "0.16.2"
+__version__ = "0.17.0"
 
 hookimpl = HookimplMarker("django_bird")

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -4,4 +4,4 @@ from django_bird import __version__
 
 
 def test_version():
-    assert __version__ == "0.16.2"
+    assert __version__ == "0.17.0"


### PR DESCRIPTION
- `3c72e22`: Update Django 5.2 version to beta (#208)
- `6253fdb`: [pre-commit.ci] pre-commit autoupdate (#209)
- `12a57f4`: [pre-commit.ci] pre-commit autoupdate (#210)
- `491290b`: Add component domain utilities for asset manifest optimization (#211)
- `a5a7995`: Add asset manifest system for better performance (#212)
- `25d40a1`: Optimize startup time by removing component discovery (#213)
- `fb976dd`: Remove component discovery at startup (#214)
- `9dd2c81`: Log any potential encoding errors in template scanning (#215)
- `8739324`: Remove `ENABLE_AUTO_CONFIG` setting and autoconfiguration functionality (#216)