### PR TITLE
:bookmark: bump version 0.17.0 -> 0.17.1

### DIFF
--- a/.copier/package.yml
+++ b/.copier/package.yml
@@ -3,7 +3,7 @@ _commit: v2024.27-4-g3fe659b
 _src_path: /home/josh/projects/work/django-twc-package
 author_email: josh@joshthomas.dev
 author_name: Josh Thomas
-current_version: 0.17.0
+current_version: 0.17.1
 django_versions:
   - "4.2"
   - "5.0"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ and this project attempts to adhere to [Semantic Versioning](https://semver.org/
 
 ## [Unreleased]
 
+## [0.17.1]
+
 ### Fixed
 
 - Fixed static asset URLs to properly include the 'django_bird' prefix, ensuring URLs match the actual file paths during collection
@@ -450,7 +452,7 @@ and this project attempts to adhere to [Semantic Versioning](https://semver.org/
 
 - Josh Thomas <josh@joshthomas.dev> (maintainer)
 
-[unreleased]: https://github.com/joshuadavidthomas/django-bird/compare/v0.17.0...HEAD
+[unreleased]: https://github.com/joshuadavidthomas/django-bird/compare/v0.17.1...HEAD
 [0.1.0]: https://github.com/joshuadavidthomas/django-bird/releases/tag/v0.1.0
 [0.1.1]: https://github.com/joshuadavidthomas/django-bird/releases/tag/v0.1.1
 [0.2.0]: https://github.com/joshuadavidthomas/django-bird/releases/tag/v0.2.0
@@ -489,3 +491,4 @@ and this project attempts to adhere to [Semantic Versioning](https://semver.org/
 [0.16.1]: https://github.com/joshuadavidthomas/django-bird/releases/tag/v0.16.1
 [0.16.2]: https://github.com/joshuadavidthomas/django-bird/releases/tag/v0.16.2
 [0.17.0]: https://github.com/joshuadavidthomas/django-bird/releases/tag/v0.17.0
+[0.17.1]: https://github.com/joshuadavidthomas/django-bird/releases/tag/v0.17.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -103,7 +103,7 @@ root = "tests"
 [tool.bumpver]
 commit = true
 commit_message = ":bookmark: bump version {old_version} -> {new_version}"
-current_version = "0.17.0"
+current_version = "0.17.1"
 push = false  # set to false for CI
 tag = false
 version_pattern = "MAJOR.MINOR.PATCH[PYTAGNUM]"

--- a/src/django_bird/__init__.py
+++ b/src/django_bird/__init__.py
@@ -2,6 +2,6 @@ from __future__ import annotations
 
 from pluggy import HookimplMarker
 
-__version__ = "0.17.0"
+__version__ = "0.17.1"
 
 hookimpl = HookimplMarker("django_bird")

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -4,4 +4,4 @@ from django_bird import __version__
 
 
 def test_version():
-    assert __version__ == "0.17.0"
+    assert __version__ == "0.17.1"


### PR DESCRIPTION
- `f15bd05`: Fix static URLs to include django_bird prefix (#219)