### PR TITLE
Normalize paths in asset manifest for enhanced security

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ and this project attempts to adhere to [Semantic Versioning](https://semver.org/
 
 ### Security
 
-- Normalize paths in asset manifest to prevent leaking system information like Python version and installation paths
+- Normalize paths in asset manifest to prevent leaking system-specific information like Python version and installation paths
 
 ## [0.17.1]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ and this project attempts to adhere to [Semantic Versioning](https://semver.org/
 
 ## [Unreleased]
 
+### Security
+
+- Normalize paths in asset manifest to prevent leaking system information like Python version and installation paths
+
 ## [0.17.1]
 
 ### Fixed

--- a/src/django_bird/manifest.py
+++ b/src/django_bird/manifest.py
@@ -28,8 +28,8 @@ def normalize_path(path: str) -> str:
         if len(parts) > 1:
             return f"pkg:{parts[1]}"
 
-    if hasattr(settings, "BASE_DIR") and settings.BASE_DIR:
-        base_dir = Path(settings.BASE_DIR).resolve()
+    if hasattr(settings, "BASE_DIR") and settings.BASE_DIR:  # type: ignore[misc]
+        base_dir = Path(settings.BASE_DIR).resolve()  # type: ignore[misc]
         abs_path = Path(path).resolve()
         try:
             if str(abs_path).startswith(str(base_dir)):

--- a/src/django_bird/manifest.py
+++ b/src/django_bird/manifest.py
@@ -23,13 +23,11 @@ def normalize_path(path: str) -> str:
     Returns:
         str: A normalized path without system-specific details
     """
-    # Handle site-packages paths (installed packages)
     if "site-packages" in path:
         parts = path.split("site-packages/")
         if len(parts) > 1:
             return f"pkg:{parts[1]}"
 
-    # Handle project paths - try to make them relative to project root
     if hasattr(settings, "BASE_DIR") and settings.BASE_DIR:
         base_dir = Path(settings.BASE_DIR).resolve()
         abs_path = Path(path).resolve()
@@ -41,7 +39,6 @@ def normalize_path(path: str) -> str:
             # Path is not relative to BASE_DIR
             pass
 
-    # Hash other paths to obscure them
     if path.startswith("/"):
         hash_val = hashlib.md5(path.encode()).hexdigest()[:8]
         filename = Path(path).name
@@ -95,6 +92,7 @@ def generate_asset_manifest() -> dict[str, list[str]]:
         dict[str, list[str]]: A dictionary mapping template paths to lists of component names.
     """
     template_component_map: dict[str, set[str]] = {}
+
     for template_path, component_names in gather_bird_tag_template_usage():
         # Convert Path objects to strings for JSON and normalize
         original_path = str(template_path)
@@ -119,8 +117,8 @@ def save_asset_manifest(manifest_data: dict[str, list[str]], path: Path | str) -
     path_obj = Path(path)
     path_obj.parent.mkdir(parents=True, exist_ok=True)
 
-    # Normalize paths in the manifest data
     normalized_manifest = {}
+
     for template_path, components in manifest_data.items():
         normalized_path = normalize_path(template_path)
         normalized_manifest[normalized_path] = components

--- a/src/django_bird/templatetags/tags/asset.py
+++ b/src/django_bird/templatetags/tags/asset.py
@@ -37,6 +37,7 @@ class AssetNode(template.Node):
     @override
     def render(self, context: Context) -> str:
         from django_bird.components import components
+        from django_bird.manifest import normalize_path
         from django_bird.staticfiles import Asset
         from django_bird.staticfiles import get_component_assets
 
@@ -45,15 +46,16 @@ class AssetNode(template.Node):
             return ""
 
         template_path = template.origin.name
+        normalized_path = normalize_path(template_path)
 
         used_components = []
 
         # Only use manifest in production mode
         if not settings.DEBUG:
             manifest = load_asset_manifest()
-            if manifest and template_path in manifest:
+            if manifest and normalized_path in manifest:
                 # Use manifest for component names in production
-                component_names = manifest[template_path]
+                component_names = manifest[normalized_path]
                 used_components = [
                     components.get_component(name) for name in component_names
                 ]

--- a/src/django_bird/templatetags/tags/asset.py
+++ b/src/django_bird/templatetags/tags/asset.py
@@ -12,6 +12,7 @@ from django.template.context import Context
 
 from django_bird._typing import override
 from django_bird.manifest import load_asset_manifest
+from django_bird.manifest import normalize_path
 
 
 class AssetTag(Enum):
@@ -37,7 +38,6 @@ class AssetNode(template.Node):
     @override
     def render(self, context: Context) -> str:
         from django_bird.components import components
-        from django_bird.manifest import normalize_path
         from django_bird.staticfiles import Asset
         from django_bird.staticfiles import get_component_assets
 

--- a/src/django_bird/templatetags/tags/asset.py
+++ b/src/django_bird/templatetags/tags/asset.py
@@ -46,15 +46,14 @@ class AssetNode(template.Node):
             return ""
 
         template_path = template.origin.name
-        normalized_path = normalize_path(template_path)
 
         used_components = []
 
         # Only use manifest in production mode
         if not settings.DEBUG:
             manifest = load_asset_manifest()
+            normalized_path = normalize_path(template_path)
             if manifest and normalized_path in manifest:
-                # Use manifest for component names in production
                 component_names = manifest[normalized_path]
                 used_components = [
                     components.get_component(name) for name in component_names

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -139,6 +139,37 @@ def test_load_asset_manifest_static_root_permission_error(static_root, monkeypat
     assert loaded_manifest is None
 
 
+def test_normalize_path():
+    # Test site-packages normalization
+    site_pkg_path = "/usr/local/lib/python3.12/site-packages/django_twc_ui/components/templates/bird/modal/modal.html"
+    from django_bird.manifest import normalize_path
+
+    assert (
+        normalize_path(site_pkg_path)
+        == "pkg:django_twc_ui/components/templates/bird/modal/modal.html"
+    )
+
+    # Test project path normalization (with BASE_DIR)
+    with override_settings(BASE_DIR="/var/home/user/project"):
+        project_path = (
+            "/var/home/user/project/app/templates/invoices/pending_invoice_list.html"
+        )
+        assert (
+            normalize_path(project_path)
+            == "app:app/templates/invoices/pending_invoice_list.html"
+        )
+
+    # Test other absolute path normalization
+    other_path = "/some/random/external/path.html"
+    normalized = normalize_path(other_path)
+    assert normalized.startswith("ext:")
+    assert "path.html" in normalized
+
+    # Test relative path remains unchanged
+    rel_path = "relative/path.html"
+    assert normalize_path(rel_path) == rel_path
+
+
 def test_generate_asset_manifest(templates_dir, registry):
     template1 = templates_dir / "test_manifest1.html"
     template1.write_text("""
@@ -181,18 +212,37 @@ def test_generate_asset_manifest(templates_dir, registry):
 
     manifest = generate_asset_manifest()
 
-    all_keys = list(manifest.keys())
-    template1_key = [k for k in all_keys if str(template1) in k][0]
-    template2_key = [k for k in all_keys if str(template2) in k][0]
+    # Check for normalized paths
+    for key in manifest.keys():
+        # Keys should not be absolute paths starting with /
+        assert not key.startswith("/"), f"Found absolute path in manifest: {key}"
 
-    assert sorted(manifest[template1_key]) == sorted(["button", "card"])
-    assert sorted(manifest[template2_key]) == sorted(["accordion", "tab"])
+    # Find the templates by looking for partial matches in the normalized paths
+    template1_components = []
+    template2_components = []
+
+    for key, components in manifest.items():
+        if "test_manifest1.html" in key:
+            template1_components = components
+        elif "test_manifest2.html" in key:
+            template2_components = components
+
+    assert sorted(template1_components) == sorted(["button", "card"])
+    assert sorted(template2_components) == sorted(["accordion", "tab"])
 
 
 def test_save_and_load_asset_manifest(tmp_path):
+    from django_bird.manifest import normalize_path
+
     test_manifest_data = {
         "/path/to/template1.html": ["button", "card"],
         "/path/to/template2.html": ["accordion", "tab"],
+    }
+
+    # Create the expected normalized data
+    expected_normalized_data = {
+        normalize_path("/path/to/template1.html"): ["button", "card"],
+        normalize_path("/path/to/template2.html"): ["accordion", "tab"],
     }
 
     output_path = tmp_path / "test-manifest.json"
@@ -204,7 +254,7 @@ def test_save_and_load_asset_manifest(tmp_path):
     with open(output_path) as f:
         loaded_data = json.load(f)
 
-    assert loaded_data == test_manifest_data
+    assert loaded_data == expected_normalized_data
 
 
 def test_default_manifest_path():


### PR DESCRIPTION
- Add path normalization to obscure system-specific information in manifest
- Convert system paths to avoid leaking environment details
- Update tests to account for normalized paths