### PR TITLE
Fix asset URL handling in development mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,10 @@ and this project attempts to adhere to [Semantic Versioning](https://semver.org/
 
 - Normalize paths in asset manifest to prevent leaking system-specific information like Python version and installation paths
 
+### Fixed
+
+- Fixed asset URL handling in development mode to exclude the "django_bird/" prefix, matching the actual file paths in development environments. Production mode (DEBUG=False) still uses the prefix to maintain compatibility with collected static files.
+
 ## [0.17.1]
 
 ### Fixed

--- a/src/django_bird/staticfiles.py
+++ b/src/django_bird/staticfiles.py
@@ -181,8 +181,8 @@ class BirdAssetStorage(StaticFilesStorage):
             return super().url(name)
         # Only add prefix in production (when DEBUG is False)
         # In development, asset paths don't include the app label prefix
-        # because they come directly from source directories
-        # In production, assets are collected to STATIC_ROOT/django_bird/
+        # because they come directly from source directories and in production,
+        # assets are collected to STATIC_ROOT/django_bird/
         if not settings.DEBUG and not name.startswith(f"{self.prefix}/"):
             name = f"{self.prefix}/{name}"
         return super().url(name)

--- a/src/django_bird/staticfiles.py
+++ b/src/django_bird/staticfiles.py
@@ -12,6 +12,7 @@ from typing import Literal
 from typing import final
 from typing import overload
 
+from django.conf import settings
 from django.contrib.staticfiles import finders
 from django.contrib.staticfiles.finders import BaseFinder
 from django.contrib.staticfiles.storage import StaticFilesStorage
@@ -178,7 +179,11 @@ class BirdAssetStorage(StaticFilesStorage):
     def url(self, name: str | None) -> str:
         if name is None:
             return super().url(name)
-        if not name.startswith(f"{self.prefix}/"):
+        # Only add prefix in production (when DEBUG is False)
+        # In development, asset paths don't include the app label prefix
+        # because they come directly from source directories
+        # In production, assets are collected to STATIC_ROOT/django_bird/
+        if not settings.DEBUG and not name.startswith(f"{self.prefix}/"):
             name = f"{self.prefix}/{name}"
         return super().url(name)
 

--- a/tests/templatetags/test_asset.py
+++ b/tests/templatetags/test_asset.py
@@ -480,7 +480,7 @@ class TestManifest:
             rendered = template.render({})
 
             assert (
-                f'<link rel="stylesheet" href="/static/django_bird/bird/{button_css.file.name}">'
+                f'<link rel="stylesheet" href="/static/bird/{button_css.file.name}">'
                 in rendered
             )
 

--- a/tests/test_staticfiles.py
+++ b/tests/test_staticfiles.py
@@ -217,6 +217,37 @@ class TestAssetClass:
             == f"/static/django_bird/{button_css.file.parent.name}/{button_css.file.name}"
         )
 
+    def test_url_debug_vs_production(self, templates_dir):
+        """Test that asset URLs are correctly generated in both debug and production modes."""
+        from django.test import override_settings
+
+        button = TestComponent(
+            name="button",
+            content="<button>Click me</button>",
+        ).create(templates_dir)
+        button_css = TestAsset(
+            component=button,
+            content=".button { color: blue; }",
+            asset_type=CSS,
+        ).create()
+
+        component = Component.from_name(button.name)
+        asset = component.get_asset(button_css.file.name)
+
+        # Test production mode (DEBUG=False)
+        with override_settings(DEBUG=False):
+            assert (
+                asset.url
+                == f"/static/django_bird/{button_css.file.parent.name}/{button_css.file.name}"
+            )
+
+        # Test development mode (DEBUG=True)
+        with override_settings(DEBUG=True):
+            assert (
+                asset.url
+                == f"/static/{button_css.file.parent.name}/{button_css.file.name}"
+            )
+
     def test_url_nonexistent(self, templates_dir):
         button = TestComponent(
             name="button",


### PR DESCRIPTION
Fix asset URL handling to exclude the django_bird prefix in development mode, while maintaining it in production mode. This ensures that static assets are correctly referenced in both environments:

- In development: static/bird/modal.js
- In production: static/django_bird/bird/modal.js