### PR TITLE
Fix asset manifest path normalization to prevent double prefixing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ and this project attempts to adhere to [Semantic Versioning](https://semver.org/
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed path normalization in asset manifest to prevent double-prefixing of already normalized paths (e.g., preventing "app:app:templates/file.html").
+
 ## [0.17.2]
 
 ### Security
@@ -27,7 +31,6 @@ and this project attempts to adhere to [Semantic Versioning](https://semver.org/
 ### Fixed
 
 - Fixed asset URL handling in development mode to exclude the "django_bird/" prefix, matching the actual file paths in development environments. Production mode (DEBUG=False) still uses the prefix to maintain compatibility with collected static files.
-- Fixed path normalization in asset manifest to prevent double-prefixing of already normalized paths (e.g., preventing "app:app:templates/file.html").
 
 ## [0.17.1]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project attempts to adhere to [Semantic Versioning](https://semver.org/
 ### Fixed
 
 - Fixed asset URL handling in development mode to exclude the "django_bird/" prefix, matching the actual file paths in development environments. Production mode (DEBUG=False) still uses the prefix to maintain compatibility with collected static files.
+- Fixed path normalization in asset manifest to prevent double-prefixing of already normalized paths (e.g., preventing "app:app:templates/file.html").
 
 ## [0.17.1]
 

--- a/src/django_bird/manifest.py
+++ b/src/django_bird/manifest.py
@@ -23,6 +23,10 @@ def normalize_path(path: str) -> str:
     Returns:
         str: A normalized path without system-specific details
     """
+    # Check if path is already normalized (has a prefix)
+    if path.startswith(("pkg:", "app:", "ext:")):
+        return path
+
     if "site-packages" in path:
         parts = path.split("site-packages/")
         if len(parts) > 1:
@@ -117,14 +121,10 @@ def save_asset_manifest(manifest_data: dict[str, list[str]], path: Path | str) -
     path_obj = Path(path)
     path_obj.parent.mkdir(parents=True, exist_ok=True)
 
-    normalized_manifest = {}
-
-    for template_path, components in manifest_data.items():
-        normalized_path = normalize_path(template_path)
-        normalized_manifest[normalized_path] = components
-
+    # The paths in manifest_data should already be normalized from the generate_asset_manifest
+    # function, so we can just save it directly
     with open(path_obj, "w") as f:
-        json.dump(normalized_manifest, f, indent=2)
+        json.dump(manifest_data, f, indent=2)
 
 
 def default_manifest_path() -> Path:

--- a/src/django_bird/manifest.py
+++ b/src/django_bird/manifest.py
@@ -16,7 +16,7 @@ _manifest_cache = None
 
 
 class PathPrefix(str, Enum):
-    """Enumeration of path prefixes used for normalizing template paths."""
+    """Path prefixes used for normalizing template paths."""
 
     PKG = "pkg:"
     APP = "app:"


### PR DESCRIPTION
This fixes an issue where paths in the asset manifest could be doubly
normalized, leading to values like "app:app:templates/file.html". The fix:

1. Updated normalize_path to skip normalization on paths that already have
   a prefix (pkg:, app:, ext:)
2. Removed redundant normalization in save_asset_manifest since paths from
   generate_asset_manifest are already normalized