### PR TITLE
:bookmark: bump version 0.17.2 -> 0.17.3

### DIFF
--- a/.copier/package.yml
+++ b/.copier/package.yml
@@ -3,7 +3,7 @@ _commit: v2024.27-4-g3fe659b
 _src_path: /home/josh/projects/work/django-twc-package
 author_email: josh@joshthomas.dev
 author_name: Josh Thomas
-current_version: 0.17.2
+current_version: 0.17.3
 django_versions:
   - "4.2"
   - "5.0"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ and this project attempts to adhere to [Semantic Versioning](https://semver.org/
 
 ## [Unreleased]
 
+## [0.17.3]
+
 ### Added
 
 - Added new `ADD_ASSET_PREFIX` setting to control how the app label prefix is added to asset URLs. This setting provides more flexibility than the previous DEBUG-based behavior, especially useful in test environments.
@@ -470,7 +472,7 @@ and this project attempts to adhere to [Semantic Versioning](https://semver.org/
 
 - Josh Thomas <josh@joshthomas.dev> (maintainer)
 
-[unreleased]: https://github.com/joshuadavidthomas/django-bird/compare/v0.17.2...HEAD
+[unreleased]: https://github.com/joshuadavidthomas/django-bird/compare/v0.17.3...HEAD
 [0.1.0]: https://github.com/joshuadavidthomas/django-bird/releases/tag/v0.1.0
 [0.1.1]: https://github.com/joshuadavidthomas/django-bird/releases/tag/v0.1.1
 [0.2.0]: https://github.com/joshuadavidthomas/django-bird/releases/tag/v0.2.0
@@ -511,3 +513,4 @@ and this project attempts to adhere to [Semantic Versioning](https://semver.org/
 [0.17.0]: https://github.com/joshuadavidthomas/django-bird/releases/tag/v0.17.0
 [0.17.1]: https://github.com/joshuadavidthomas/django-bird/releases/tag/v0.17.1
 [0.17.2]: https://github.com/joshuadavidthomas/django-bird/releases/tag/v0.17.2
+[0.17.3]: https://github.com/joshuadavidthomas/django-bird/releases/tag/v0.17.3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -103,7 +103,7 @@ root = "tests"
 [tool.bumpver]
 commit = true
 commit_message = ":bookmark: bump version {old_version} -> {new_version}"
-current_version = "0.17.2"
+current_version = "0.17.3"
 push = false  # set to false for CI
 tag = false
 version_pattern = "MAJOR.MINOR.PATCH[PYTAGNUM]"

--- a/src/django_bird/__init__.py
+++ b/src/django_bird/__init__.py
@@ -2,6 +2,6 @@ from __future__ import annotations
 
 from pluggy import HookimplMarker
 
-__version__ = "0.17.2"
+__version__ = "0.17.3"
 
 hookimpl = HookimplMarker("django_bird")

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -4,4 +4,4 @@ from django_bird import __version__
 
 
 def test_version():
-    assert __version__ == "0.17.2"
+    assert __version__ == "0.17.3"


### PR DESCRIPTION
- `2c2b69c`: Fix asset manifest path normalization to prevent double prefixing (#224)